### PR TITLE
Implement message history

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,9 +4,13 @@ PODS:
 DEPENDENCIES:
   - Starscream (~> 2.0.4)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Starscream
+
 SPEC CHECKSUMS:
   Starscream: df5974ee928b157c8eda8af8de7c620276b7dfcc
 
 PODFILE CHECKSUM: 4b18658018b76ee08b6ba136e183e158787e02a6
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.2

--- a/scaledrone-swift.xcodeproj/project.pbxproj
+++ b/scaledrone-swift.xcodeproj/project.pbxproj
@@ -103,7 +103,6 @@
 				B6F3B83E1F3F69CE0063002B /* Frameworks */,
 				B6F3B83F1F3F69CE0063002B /* Resources */,
 				4CDEEF13A8ED0579CAEA2047 /* [CP] Embed Pods Frameworks */,
-				9B4B9170C983381489590CC0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -196,21 +195,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-scaledrone-swift/Pods-scaledrone-swift-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9B4B9170C983381489590CC0 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-scaledrone-swift/Pods-scaledrone-swift-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
Handle message history messages and delegate them to the client in the correct order.
Fix a couple of warnings.
Should be backwards compatible with older versions, the only public-facing API change is an optional `messageHistory` parameter on `Scaledrone.subscribe`.

There are some changes to the project file because I installed the pods with the latest version of CocoaPods.